### PR TITLE
Complex updates

### DIFF
--- a/jqi/completer.py
+++ b/jqi/completer.py
@@ -11,7 +11,7 @@ class Completion(Exception):
 # return the union of keys of objects in the stream
 def sample_objects(stream):
     keys = set()
-    for item in stream:
+    for env, item in stream:
         try:
             keys.update(item.keys())
         except AttributeError:
@@ -29,12 +29,12 @@ def field_name(k):
 def complete_term(term, evaluator):
     if term == Token("."):
         pos = (term.start + 1, term.end)
-        def complete_term(env, stream):
+        def complete_term(stream):
             samples = sample_objects(stream)
             raise Completion(completions=[Token("")] + [field_name(k) for k in samples], pos=pos)
         return complete_term
     elif isinstance(term, (Field, PartialString)):
-        def complete_term(env, stream):
+        def complete_term(stream):
             samples = sample_objects(stream)
             raise Completion(completions=[field_name(k) for k in samples if k.startswith(term)], pos=term.pos)
         return complete_term
@@ -43,8 +43,8 @@ def complete_term(term, evaluator):
 
 
 def complete_field(prefix, evaluator):
-    def complete_field(env, stream):
-        _, stream = evaluator(env, stream)
+    def complete_field(stream):
+        stream = evaluator(stream)
         samples = sample_objects(stream)
         raise Completion(completions=[field_name(k) for k in samples if k.startswith(prefix)], pos=prefix.pos)
     return complete_field

--- a/jqi/completion.py
+++ b/jqi/completion.py
@@ -1,7 +1,7 @@
 from .lexer import lex
 from .parser import exp
 from .completer import *
-from .eval import make_env
+from .eval import make_env, splice
 
 
 def completer(s, offset, start=exp):
@@ -12,7 +12,7 @@ def completer(s, offset, start=exp):
             env = {}
         env = make_env().update(env)    # Install standard bindings
         try:
-            _, _ = evaluator(env, stream)
+            _ = evaluator(splice(env, stream))
             return []
         except Completion as c:
             return c.completions, c.pos

--- a/jqi/eval.py
+++ b/jqi/eval.py
@@ -15,7 +15,6 @@ impossible to implement.
 In time, all of these will be addressed (probably together).
 """
 
-from copy import deepcopy
 from numbers import Number
 import operator
 
@@ -229,14 +228,15 @@ def set_path(lhs, rhs):
     def set_path(env, stream):
         results = []
         for item in stream:
-            env2, lvalues = lhs(env, [item])
-            path = env2.get_path()
-            for lvalue in lvalues:
-                _, values = rhs(env, stream)
-                for value in values:
-                    # TODO: construct the updated item and return it
+            _, values = rhs(env, stream)
+            for value in values:
+                # TODO: construct the updated item and return it
+                result = item
+                env2, lvalues = lhs(env, [item])
+                path = env2.get_path()
+                for lvalue in lvalues:
                     result = deep_update(item, path, value)
-                    results.append(result)
+            results.append(result)
         return env, results
     return set_path
 

--- a/jqi/function.py
+++ b/jqi/function.py
@@ -21,30 +21,30 @@ def register(func):
 
 @register
 def false(env, item):
-    return env, [False]
+    return [(env, False)]
 
 
 @register
 def true(env, item):
-    return env, [True]
+    return [(env, True)]
 
 
 @register
 def null(env, item):
-    return env, [None]
+    return [(env, None)]
 
 
 @register
 def not_(env, item):
-    return env, [not _truth(item)]
+    return [(env, not _truth(item))]
 
 
 @register
 def empty(env, item):
-    return env, []
+    return []
 
 
 @register
 def select(env, item, test):
-    _, vs = test(env, [item])
-    return env, [item for v in vs if _truth(v)]
+    vs = test([(env, item)])
+    return [(env, item) for (_, v) in vs if _truth(v)]

--- a/jqi/pattern.py
+++ b/jqi/pattern.py
@@ -8,7 +8,7 @@ from .lexer import Ident, Str
 
 
 class Match:
-    def bindings(self, env, stream, item):
+    def bindings(self, stream, item):
         # Return a stream of bindings to use
         raise NotImplementedError("bindings")
 
@@ -17,7 +17,7 @@ class ValueMatch(Match):
     def __init__(self, target):
         self.target = "${}".format(target)
 
-    def bindings(self, env, stream, item):
+    def bindings(self, stream, item):
         return [{self.target: item}]
 
 
@@ -25,25 +25,25 @@ class ArrayMatch(Match):
     def __init__(self, *targets):
         self.targets = targets
 
-    def bindings(self, env, stream, item):
+    def bindings(self, stream, item):
         if item is None:
             item = []
         elif not isinstance(item, list):
             raise ValueError("cannot index {} with number".format(type(item).__name__))
-        return self._bindings(env, stream, item, self.targets)
+        return self._bindings(stream, item, self.targets)
 
-    def _bindings(self, env, stream, item, targets):
+    def _bindings(self, stream, item, targets):
         if len(targets) == 0:
             return [{}]
 
         if len(item) == 0:
             # Bind the rest against None
-            results = targets[0].bindings(env, stream, None)
+            results = targets[0].bindings(stream, None)
         else:
-            results = targets[0].bindings(env, stream, item[0])
+            results = targets[0].bindings(stream, item[0])
 
         total = []
-        for other in self._bindings(env, stream, item[1:], targets[1:]):
+        for other in self._bindings(stream, item[1:], targets[1:]):
             for result in results:
                 this_binding = dict(result)
                 this_binding.update(other)
@@ -55,22 +55,22 @@ class ObjectMatch(Match):
     def __init__(self, *targets):
         self.targets = targets
 
-    def bindings(self, env, stream, item):
+    def bindings(self, stream, item):
         if item is None:
             item = {}
         elif not isinstance(item, dict):
             raise ValueError("cannot index {} with string".format(type(item).__name__))
-        return self._bindings(env, stream, item, self.targets)
+        return self._bindings(stream, item, self.targets)
 
-    def _bindings(self, env, stream, item, targets):
+    def _bindings(self, stream, item, targets):
         if len(targets) == 0:
             return [{}]
 
-        results = targets[0].bindings(env, stream, item)
+        results = targets[0].bindings(stream, item)
 
         total = []
         for result in results:
-            for other in self._bindings(env, stream, item, targets[1:]):
+            for other in self._bindings(stream, item, targets[1:]):
                 this_binding = dict(result)
                 this_binding.update(other)
                 total.append(this_binding)
@@ -82,12 +82,12 @@ class KeyMatch(Match):
         self.key = str(key)
         self.matcher = matcher
 
-    def bindings(self, env, stream, item):
+    def bindings(self, stream, item):
         if item is None:
             item = {}
         elif not isinstance(item, dict):
             raise ValueError("cannot index {} with string".format(type(item).__name__))
-        return self.matcher.bindings(env, stream, item.get(self.key))
+        return self.matcher.bindings(stream, item.get(self.key))
 
 
 class ExpMatch(Match):
@@ -95,13 +95,13 @@ class ExpMatch(Match):
         self.exp = exp
         self.matcher = matcher
 
-    def bindings(self, env, stream, item):
+    def bindings(self, stream, item):
         if item is None:
             item = {}
         elif not isinstance(item, dict):
             raise ValueError("cannot index {} with string".format(type(item).__name__))
         results = []
-        _, keys = self.exp(env, stream)
-        for key in keys:
-            results.extend(self.matcher.bindings(env, stream, item.get(str(key))))
+        keys = self.exp(stream)
+        for env, key in keys:
+            results.extend(self.matcher.bindings(stream, item.get(str(key))))
         return results

--- a/test/test_eval.py
+++ b/test/test_eval.py
@@ -1,6 +1,6 @@
 import pytest
 from jqi.parser import parse, Token, Field, Ident, term, exp, ParseError
-from jqi.eval import make_env, pipe, binding, literal, variable
+from jqi.eval import make_env, pipe, binding, literal, variable, splice
 from jqi.pattern import *
 
 
@@ -19,10 +19,12 @@ def test_variable():
     evaluator = parse("$x", start=exp)
     env = make_env()
     env.update({"$x": 1})
-    assert evaluator(env, [None]) == (env, [1])
+    assert evaluator(splice(env, [None])) == splice(env, [1])
 
 
 def test_binding():
     env = make_env()
     evaluator = binding(literal(1), ValueMatch("x"), variable("x"))
-    assert evaluator(env, [None]) == (env, [1])
+    result = evaluator(splice(env, [None]))
+    expected_env = env.child({"$x": 1})
+    assert result == splice(expected_env, [1])

--- a/test/test_function.py
+++ b/test/test_function.py
@@ -1,7 +1,7 @@
 import pytest
 from jqi.parser import parse, Token, Field, Ident, term, exp, ParseError
 from jqi.error import Error
-from jqi.eval import make_env
+from jqi.eval import make_env, splice, unsplice
 from jqi import parser
 
 
@@ -33,4 +33,4 @@ def test_func(input, stream, result):
             parse(input, start=term)
         return
     env = make_env()
-    assert parse(input, start=exp)(env, stream) == (env, result)
+    assert unsplice(parse(input, start=exp)(splice(env, stream))) == result

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1,7 +1,7 @@
 import pytest
 from jqi.parser import parse, Token, Field, Ident, term, exp, ParseError
 from jqi.error import Error
-from jqi.eval import make_env
+from jqi.eval import make_env, splice, unsplice
 from jqi import parser
 
 
@@ -40,7 +40,7 @@ def test_term(input, stream, result):
             parse(input, start=term)
         return
     env = make_env()
-    assert parse(input, start=term)(env, stream) == (env, result)
+    assert parse(input, start=term)(splice(env, stream)) == splice(env, result)
 
 
 def test_field():
@@ -91,4 +91,4 @@ def test_exp(input, stream, result):
             parse(input, start=term)
         return
     env = make_env()
-    assert parse(input, start=exp)(env, stream) == (env, result)
+    assert unsplice(parse(input, start=exp)(splice(env, stream))) == result

--- a/test/test_pattern.py
+++ b/test/test_pattern.py
@@ -2,7 +2,7 @@ import pytest
 from jqi.parser import parse, Token, Field, Ident, term, exp, ParseError
 from jqi.pattern import *
 from jqi.error import Error
-from jqi.eval import make_env, comma, literal
+from jqi.eval import make_env, comma, literal, splice, unsplice
 
 
 def simplify(x):
@@ -37,12 +37,12 @@ def simplify(x):
 ], ids=simplify)
 def test_destructure(item, target, result):
     env = make_env()
-    stream = [None]
+    stream = splice(env, [None])
     if isinstance(result, type) and issubclass(result, Exception):
         with pytest.raises(result):
-            target.bindings(env, stream, item)
+            target.bindings(stream, item)
         return
-    assert target.bindings(env, stream, item) == result
+    assert target.bindings(stream, item) == result
 
 
 @pytest.mark.parametrize("input,stream,result", [
@@ -69,5 +69,5 @@ def test_parser(input, stream, result):
             parse(input, start=term)
         return
     env = make_env()
-    assert parse(input, start=exp)(env, stream) == (env, result)
+    assert unsplice(parse(input, start=exp)(splice(env, stream))) == result
 

--- a/test/test_updates.py
+++ b/test/test_updates.py
@@ -1,6 +1,6 @@
 import pytest
 from jqi.parser import parse, Token, Field, Ident, term, exp, ParseError
-from jqi.eval import make_env, pipe, binding, literal, variable
+from jqi.eval import make_env, pipe, binding, literal, variable, splice, unsplice
 from jqi.pattern import *
 
 
@@ -32,4 +32,4 @@ def test_updates(input, stream, result):
             parse(input, start=term)
         return
     env = make_env()
-    assert parse(input, start=exp)(env, stream) == (env, result)
+    assert unsplice(parse(input, start=exp)(splice(env, stream))) == result

--- a/test/test_updates.py
+++ b/test/test_updates.py
@@ -24,6 +24,7 @@ def simplify(x):
     ('.a | .b.c = 2', [{}], [{"a": {"b": {"c": 2}}}]),
     ('.a."b".c = 2', [{}], [{"a": {"b": {"c": 2}}}]),
     ('.a | . | .c = 2', [{}], [{"a": {"c": 2}}]),
+    ('. | (.a, .b) = (1, 2)', [None], [{"a": 1, "b": 1}, {"a": 2, "b": 2}]),
 ], ids=simplify)
 def test_updates(input, stream, result):
     if isinstance(result, type) and issubclass(result, Exception):


### PR DESCRIPTION
Refactor (for the third time) to turn value-streams into pairs of (env, value).
The point of this is mostly so that stuff like `{} | (.a, .b) = (1, 2)` will work.
What kind of idiot writes code like that?!

Anyway. Thank goodness for unit tests.