### PR TITLE
Enable sh 1.x compatability in call to `sh.jq`

### DIFF
--- a/jqi/editor.py
+++ b/jqi/editor.py
@@ -402,7 +402,7 @@ class Editor(Refresh):
             tty_args.update({"_tty_out": tty})
 
         try:
-            proc = sh.jq(*args, _in=self.input, _out=out, _err=err, **tty_args)
+            proc = sh.jq(*args, _in=self.input, _out=out, _err=err, _return_cmd=True, **tty_args)
             proc.wait()
             if not stdio:
                 out = out.getvalue()


### PR DESCRIPTION
In sh 2.x this function returns a `str` rather than a `RunningCommand` which has no `wait()` method. Adding `_return_cmd=True` here restores the 1.x behaviour.